### PR TITLE
Add block comment support

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -25,6 +25,7 @@ export default {
         return languages
       },
       checkedScopes: {
+        'comment.block.latex': checkComments,
         'comment.line.at-sign.bibtex': checkComments,
         'comment.line.percentage.tex': checkComments,
         'comment.line.percentage.latex': checkComments,


### PR DESCRIPTION
Adds support for the `comment` environment. This is an explicitly valid scope in the [textmate documentation](https://manual.macromates.com/en/language_grammars).

```latex
\begin{comment}
This is a block comment
\end{comment}
```

It could possibly have `environment` in the scope somewhere? I don't really understand the existing scopes in `language-latex`, as they seem to be a mix of convenience for syntax highlighting and trying to approximate the types of actual programming languages. I just merged support for this environment into `language-latex` with the scope `comment.block.latex` though, so this will work with the next release of that package.